### PR TITLE
RabbitMQ: Support for routing keys

### DIFF
--- a/driver-rabbitmq/deploy/deploy.yaml
+++ b/driver-rabbitmq/deploy/deploy.yaml
@@ -165,7 +165,7 @@
         src: ../../package/target/openmessaging-benchmark-0.0.1-SNAPSHOT-bin.tar.gz
         dest: /opt
     - shell: >
-        tuned-adm profile latency-performance &&
+        tuned-adm profile latency-performance && rm -rf /opt/benchmark &&
         mv /opt/openmessaging-benchmark-0.0.1-SNAPSHOT /opt/benchmark
     - name: Configure service URL
       lineinfile:

--- a/driver-rabbitmq/pom.xml
+++ b/driver-rabbitmq/pom.xml
@@ -21,7 +21,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
-	<parent>
+  <parent>
 		<groupId>io.openmessaging.benchmark</groupId>
 		<artifactId>messaging-benchmark</artifactId>
 		<version>0.0.1-SNAPSHOT</version>
@@ -40,5 +40,9 @@
 			<artifactId>amqp-client</artifactId>
 			<version>5.9.0</version>
 		</dependency>
-	</dependencies>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+    </dependencies>
 </project>

--- a/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqConfig.java
+++ b/driver-rabbitmq/src/main/java/io/openmessaging/benchmark/driver/rabbitmq/RabbitMqConfig.java
@@ -26,4 +26,5 @@ public class RabbitMqConfig {
     public String brokerAddress;
     public boolean messagePersistence = false;
     public QueueType queueType = QueueType.CLASSIC;
+    public boolean connectionPerChannel = false;
 }


### PR DESCRIPTION
- Add support for Topic Exchanges
- Use dedicated routing keys to simulate partitioning
- Round-robin producers over routing keys to simulate strongpoint workloads